### PR TITLE
Added EventListener to shift pixels by arrow keys and keyboard shortcuts

### DIFF
--- a/scripts/editor/functions.js
+++ b/scripts/editor/functions.js
@@ -360,6 +360,8 @@ function copyToClipboard () {
 document.addEventListener("keydown", function (event) {
   /* Event listener looking for key presses */
 
+  event.preventDefault();   // * Overrides default browser hotkeys
+
   if (event.ctrlKey) {
     switch (event.code) {
       // * All Ctrl key combinations go here
@@ -374,18 +376,15 @@ document.addEventListener("keydown", function (event) {
       case "ArrowRight":  shiftRight();
         break;
 
-      /* 
-      ! These following keys may have conflicts with the browsers' hotkeys 
-      ! You can (should) change it to whatever feels best
-      */
-      case "KeyI":        invertPixels();         // ! Ctrl+I opens bookmarks on Firefox
+      // Other function hotkeys
+      case "KeyI":        invertPixels();
         break;
-      case "KeyM":        mirrorPixels();         // ! Ctrl+M mutes tab on Firefox
+      case "KeyM":        mirrorPixels();
         break;
-      case "KeyC":        copyToPixelClipboard(); // ? may conflict if a selection exists
+      case "KeyC":        copyToPixelClipboard();
         copyToClipboard();
         break;
-      case "KeyV":        pasteToPixelEditor();   // ? may conflict if a text box is selected
+      case "KeyV":        pasteToPixelEditor();
         break;
     }
   }

--- a/scripts/editor/functions.js
+++ b/scripts/editor/functions.js
@@ -354,3 +354,24 @@ function copyToClipboard () {
   
   copyText.setSelectionRange(0, 0);  // Unselect all text
 };
+
+/* Key Listeners */
+
+document.addEventListener("keydown", function (event) {
+  /* Shifts every pixel when Ctrl and arrow keys are pressed. */
+
+  if (event.ctrlKey) {
+    /* All Ctrl key combinations go here */
+
+    switch (event.code) {
+      case "ArrowUp":     shiftUp();
+        break;
+      case "ArrowDown":   shiftDown();
+        break;
+      case "ArrowLeft":   shiftLeft();
+        break;
+      case "ArrowRight":  shiftRight();
+        break;
+    }
+  }
+});

--- a/scripts/editor/functions.js
+++ b/scripts/editor/functions.js
@@ -358,12 +358,13 @@ function copyToClipboard () {
 /* Key Listeners */
 
 document.addEventListener("keydown", function (event) {
-  /* Shifts every pixel when Ctrl and arrow keys are pressed. */
+  /* Event listener looking for key presses */
 
   if (event.ctrlKey) {
-    /* All Ctrl key combinations go here */
-
     switch (event.code) {
+      // * All Ctrl key combinations go here
+
+      // Shifts every pixel when Ctrl and arrow keys are pressed.
       case "ArrowUp":     shiftUp();
         break;
       case "ArrowDown":   shiftDown();
@@ -371,6 +372,20 @@ document.addEventListener("keydown", function (event) {
       case "ArrowLeft":   shiftLeft();
         break;
       case "ArrowRight":  shiftRight();
+        break;
+
+      /* 
+      ! These following keys may have conflicts with the browsers' hotkeys 
+      ! You can (should) change it to whatever feels best
+      */
+      case "KeyI":        invertPixels();         // ! Ctrl+I opens bookmarks on Firefox
+        break;
+      case "KeyM":        mirrorPixels();         // ! Ctrl+M mutes tab on Firefox
+        break;
+      case "KeyC":        copyToPixelClipboard(); // ? may conflict if a selection exists
+        copyToClipboard();
+        break;
+      case "KeyV":        pasteToPixelEditor();   // ? may conflict if a text box is selected
         break;
     }
   }


### PR DESCRIPTION
When `ctrl` and any arrow keys are pressed, the appropriate `shift` functions are called. More keys can be added into the `switch` statement. 

To look at additional keycodes, I reccommend using [this website](https://keycode.info/).

For other key combinations, use the altKey, metaKey or shiftKey properties.